### PR TITLE
Fix Reviews Not Downloading

### DIFF
--- a/ReviewDownloader.m
+++ b/ReviewDownloader.m
@@ -12,9 +12,9 @@
 #import "Review.h"
 #import "Version.h"
 
-NSString *const kITCReviewAPISummaryPageAction           = @"/WebObjects/iTunesConnect.woa/ra/apps/%@/reviews/summary?platform=%@";
-NSString *const kITCReviewAPISummaryVersionPageAction    = @"/WebObjects/iTunesConnect.woa/ra/apps/%@/reviews/summary?platform=%@&versionId=%@";
-NSString *const kITCReviewAPIVersionStorefrontPageAction = @"/WebObjects/iTunesConnect.woa/ra/apps/%@/reviews?platform=%@&versionId=%@&storefront=%@";
+NSString *const kITCReviewAPISummaryPageAction           = @"/ra/apps/%@/reviews/summary?platform=%@";
+NSString *const kITCReviewAPISummaryVersionPageAction    = @"/ra/apps/%@/reviews/summary?platform=%@&versionId=%@";
+NSString *const kITCReviewAPIVersionStorefrontPageAction = @"/ra/apps/%@/reviews?platform=%@&versionId=%@&storefront=%@";
 
 NSString *const kITCReviewAPIPlatformiOS = @"ios";
 NSString *const kITCReviewAPIPlatformMac = @"osx";


### PR DESCRIPTION
`kITCBaseURL` now includes `/WebObjects/iTunesConnect.woa`, so it now needs to be removed from the review APIs.
