### PR TITLE
Payments: fixed for locales with "," as decimalSeparator

### DIFF
--- a/Classes/ReportDownloadOperation.m
+++ b/Classes/ReportDownloadOperation.m
@@ -382,6 +382,7 @@ static NSString *NSStringPercentEscaped(NSString *string) {
 			
 			NSNumberFormatter *currencyFormatter = [[NSNumberFormatter alloc] init];
 			currencyFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+			currencyFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
 			
 			NSDate *currDate = [NSDate date];
 			


### PR DESCRIPTION
such as German;
couldn't parse the payment amount and showed 0€ for all payments;