### PR TITLE
Fix AccountsViewController doExport to only access UI on main thread

### DIFF
--- a/Classes/AccountsViewController.m
+++ b/Classes/AccountsViewController.m
@@ -760,7 +760,9 @@
 			
 			@synchronized(exportedReports) {
 				exportedReports = @(exportedReports.unsignedIntegerValue + 1);
-				hud.progress = ((CGFloat)exportedReports.unsignedIntegerValue / (CGFloat)totalReports);
+				dispatch_async(dispatch_get_main_queue(), ^{
+					hud.progress = ((CGFloat)exportedReports.unsignedIntegerValue / (CGFloat)totalReports);
+				});
 			}
 		};
 		
@@ -782,8 +784,10 @@
 		
 		[reportExportQueue waitUntilAllOperationsAreFinished];
 		
-		hud.mode = MBProgressHUDModeIndeterminate;
-		hud.label.text = NSLocalizedString(@"Compressing", nil);
+		dispatch_async(dispatch_get_main_queue(), ^{
+			hud.mode = MBProgressHUDModeIndeterminate;
+			hud.label.text = NSLocalizedString(@"Compressing", nil);
+		});
 		
 		ZIPArchive *zipArchive = [[ZIPArchive alloc] initWithFileURL:exportedReportsZipFileURL];
 		[zipArchive addDirectoryToArchive:exportURL];


### PR DESCRIPTION
The doExport method of AccountsViewController was modifying the ASProgressHUD from a background thread, causing a crash in debug builds.