### PR TITLE
Crash fix

### DIFF
--- a/Classes/Product.h
+++ b/Classes/Product.h
@@ -14,6 +14,7 @@
 #define kProductPlatformUniversal		            @"Universal"
 #define kProductPlatformMac				            @"Mac"
 #define kProductPlatformInApp			            @"In-App"
+#define kProductPlatformMacInApp                    @"Mac In-App"
 #define kProductPlatformAppBundle		            @"App Bundle"
 #define kProductPlatformMacAppBundle	            @"Mac App Bundle"
 #define kProductPlatformRenewableSubscription       @"Renewable Sub"

--- a/Classes/Report.m
+++ b/Classes/Report.m
@@ -198,7 +198,9 @@
 										   @"F3": kProductPlatformMac,
 										   @"F7": kProductPlatformMac,
 										   @"IA1": kProductPlatformInApp,
+                                           @"IA1-M": kProductPlatformMacInApp,
 										   @"IA9": kProductPlatformInApp,
+                                           @"IA9-M": kProductPlatformMacInApp,
 										   @"1-B": kProductPlatformAppBundle,
 										   @"F1-B": kProductPlatformMacAppBundle,
 										   @"IAY": kProductPlatformRenewableSubscription,
@@ -536,6 +538,12 @@
 							@"1. ",		//iPhone App
 							@"1-B",		//App Bundle
 							@"1-B. ",	//App Bundle
+                            @"1E",      //Custom iPhone App
+                            @"1E. ",    //Custom iPhone App
+                            @"1EP",     //Custom iPad App
+                            @"1EP. ",   //Custom iPad App
+                            @"1EU",     //Custom Universal App
+                            @"1EU. ",   //Custom Universal App
 							@"1F",		//Universal App
 							@"1F. ",	//Universal App
 							@"1T",		//iPad App
@@ -547,13 +555,17 @@
 							@"FI1",		//Mac In-App Purchase
 							@"FI1. ",	//Mac In-App Purchase
 							@"IA1-M",	//Mac In-App Purchase
+                            @"IA1-M. ",    //Mac In-App Purchase
 							@"IA1",		//In-App Purchase
 							@"IA1. ",	//In-App Purchase
 							@"IA9",		//In-App Subscription
 							@"IA9. ",	//In-App Subscription
+                            @"IA9-M",   //In-App Subscription Mac
+                            @"IA9-M. ", //In-App Subscription Mac
 							@"IAY",		//In-App Renewable Subscription
 							@"IAY. ",	//In-App Renewable Subscription
 							@"IAY-M",	//Mac In-App Renewable Subscription
+                            @"IAY-M. ", //Mac In-App Renewable Subscription
 							@"IAC",		//In-App Free Subscription
 							@"IAC. "	//In-App Free Subscription
 							@"1.GP",	//GP = Gift Purchase
@@ -683,7 +695,9 @@
 								@"F1",		//Mac App
 								@"IA1",		//In-App Purchase
 								@"IA9",		//In-App Subscription
+                                @"IA9-M",   //In-App Subscription (Mac)
 								@"IAY",		//In-App Auto-Renewable Subscription
+                                @"IAY-M",   //In-App Auto-Renewable Subscription (Mac)
 								@"FI1",		//Mac In-App Purchase
 								@"IA1-M",	//Mac In-App Purchase
 								@"1E",		//Paid App (Custom iPhone)

--- a/Classes/ReviewDownloadOperation.m
+++ b/Classes/ReviewDownloadOperation.m
@@ -231,7 +231,7 @@ NSString *const kITCReviewAPIPlatformMac = @"osx";
 			}
 			
 			NSDictionary *devResp = reviewData[@"developerResponse"];
-			if (devResp != nil) {
+			if (devResp != nil && devResp != (id)[NSNull null]) {
 				// Developer response was posted.
 				NSNumber *identifier = devResp[@"responseId"];
 				NSTimeInterval timeInterval = [devResp[@"lastModified"] doubleValue];


### PR DESCRIPTION
Excellent job on the recent updates.
I experienced a crash when downloading reviews due to a "<null>" string.
